### PR TITLE
Fix CircleCI JUnit XML test result collection

### DIFF
--- a/playwright.config.test.ts
+++ b/playwright.config.test.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: [
     ['html'],
-    ['junit', { outputFile: 'test-results/junit.xml' }],
+    ['junit', { outputFile: 'test-results/e2e-junit.xml' }],
     ['json', { outputFile: 'test-results/results.json' }]
   ],
   use: {
@@ -35,7 +35,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run serve -- --configuration=test',
+    command: 'npm start',
     url: 'http://localhost:4200',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,


### PR DESCRIPTION
# Fix CircleCI JUnit XML test result collection

## Summary

Resolves the CircleCI "0 test results uploaded" issue by fixing JUnit XML generation problems in both unit and E2E test configurations. The root causes were:

1. **Missing script reference**: `playwright.config.test.ts` referenced `npm run serve` which doesn't exist in `package.json` (should be `npm start`)
2. **File conflicts**: Both Karma unit tests and Playwright E2E tests were writing to the same `test-results/junit.xml` file
3. **Configuration gaps**: Missing `karma-junit-reporter` dependency and incomplete CircleCI browser orb usage

**Key Changes**:
- Fixed Playwright webServer command to use existing `npm start` script
- Separated JUnit XML outputs: `junit.xml` (unit tests) and `e2e-junit.xml` (E2E tests)
- Added `karma-junit-reporter` dependency and configured Karma to output JUnit XML
- Updated CircleCI to use Node.js v20.19 and proper browser-tools orb usage

## Review & Testing Checklist for Human

- [ ] **Verify CircleCI shows test results uploaded** instead of "0 test results uploaded" message
- [ ] **Test npm start command** works correctly and serves the app on localhost:4200
- [ ] **Check CI logs** to confirm both `test-results/junit.xml` and `test-results/e2e-junit.xml` files are generated
- [ ] **Run unit tests locally** with `npm run test:unit` and verify `test-results/junit.xml` is created (should be ~75KB)
- [ ] **Test E2E configuration** with `npx playwright test --config=playwright.config.test.ts --list` to confirm no script errors

**Recommended Test Plan**: Run the CircleCI pipeline and check the "Test Summary" tab to verify test results are properly uploaded and displayed, rather than showing "0 test results uploaded".

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    subgraph "Test Configuration Files"
        A["playwright.config.test.ts"]:::major-edit
        B["karma.conf.js"]:::minor-edit
        C["package.json"]:::minor-edit
    end
    
    subgraph "CircleCI Pipeline"
        D[".circleci/config.yml"]:::context
        E["unit-tests job"]:::context
        F["e2e-tests job"]:::context
    end
    
    subgraph "Test Results"
        G["test-results/junit.xml<br/>(Unit Tests)"]:::context
        H["test-results/e2e-junit.xml<br/>(E2E Tests)"]:::context
    end
    
    A -->|"webServer: npm start"| E
    A -->|"junit reporter"| H
    B -->|"junit reporter"| G
    C -->|"karma-junit-reporter"| B
    E -->|"store_test_results"| G
    F -->|"store_test_results"| H
    D -->|"configures"| E
    D -->|"configures"| F
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

**Local Testing Results**:
- Unit tests successfully generate `junit.xml` (75KB file confirmed)
- Playwright configuration now lists tests without script errors
- E2E tests still fail due to authentication setup, but script reference issue is resolved

**Potential Risks**:
- E2E tests may not generate JUnit XML in CI if authentication issues persist
- CircleCI environment may have different file generation timing than local testing

---

*This PR was created with assistance from Devin AI*  
*Link to Devin run: https://app.devin.ai/sessions/bd2b3c122e124b5c8c33c70100252188*  
*Requested by: @timfee*